### PR TITLE
fix typo pointing to web.compass in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ Enter the command below to start the test:
 - Once you start the exam, the test timer will start.
 
 ```terminal
-python start_exam.py -t [<EXAM_TOKEN>]
+python start_exam.py -t <EXAM_TOKEN>
 ```
 
-> Replace `<EXAM_TOKEN>` with the token provided to you [on compass](https://web.compass.lighthouselabs.com/4c01411e-afe1-464c-a9aa-d5157bb9c2b1).
+> Replace `<EXAM_TOKEN>` with the token provided to you on Compass.
 
 This command downloads the test questions to your local file system. You should see new files in the `answers/` directory.
 


### PR DESCRIPTION
Also removed unnecessary square brackets in command