### PR TITLE
Encoding fix attempt

### DIFF
--- a/lib/exam_loader.py
+++ b/lib/exam_loader.py
@@ -35,13 +35,13 @@ class ExamLoader:
             
             print(f'\tCreating Question {q["questionId"]}\t({q["maxScore"]} Points)\tAnswer file {code_path}')
 
-            with open(code_path, 'w') as f:
+            with open(code_path, 'w', encoding="utf-8") as f:
                 f.write(code_content)
 
-            with open(test_path, 'w') as f:
+            with open(test_path, 'w', encoding="utf-8") as f:
                 f.write(test_content)
 
         exam_data = {'exam_id': exam['examId'], 'token': token}
 
-        with open('./.exam-data', 'w') as f:
+        with open('./.exam-data', 'w', encoding="utf-8") as f:
             f.write(json.dumps(exam_data))

--- a/lib/test_runner.py
+++ b/lib/test_runner.py
@@ -32,17 +32,17 @@ class TestRunner:
         while not os.path.exists('./.exam-data'):
             time.sleep(1)
             
-        with open('./.exam-data', 'r') as f:
+        with open('./.exam-data', 'r', encoding="utf-8") as f:
             self.exam_data = json.loads(f.read())
 
 
     def get_student_code(self):
-        with open(f"answers/question_{self.pad_number(self.question_number)}.py", 'r') as f:
+        with open(f"answers/question_{self.pad_number(self.question_number)}.py", 'r', encoding="utf-8") as f:
             return f.read() 
     
 
     def get_test_file_hash(self):
-        with open(self.get_test_file_path(), 'r') as f:
+        with open(self.get_test_file_path(), 'r', encoding="utf-8") as f:
             test_file_content = f.read()
         
         return hashlib.md5(test_file_content.encode()).hexdigest()
@@ -116,7 +116,7 @@ class TestRunner:
         while not os.path.exists('.report.json'):
             time.sleep(1)
 
-        with open('.report.json', 'r') as f:
+        with open('.report.json', 'r', encoding="utf-8") as f:
             return json.loads(f.read())
     
     


### PR DESCRIPTION
Attempt at fixing an error that 2 students are getting re encoding

```
From Federico Alzamora to Everyone:  07:13 AM
PS C:\Users\Admin\Bootcamp\lighthouse-data-notes\Week_1\Day_5\assessment-exam-student-python> python start_exam.py -t 5ec863d9-b1a6-4ee1-9056-4b164d02fa91
Contacting Server to Start Exam with token: 5ec863d9-b1a6-4ee1-9056-4b164d02fa91
Server Response: 5 Questions:
        Creating Question 00    (30 Points)     Answer file answers/question_00.py
Traceback (most recent call last):
  File "start_exam.py", line 19, in <module>
    ExamLoader().load(token = args['exam_token'])
  File "C:\Users\Admin\Bootcamp\lighthouse-data-notes\Week_1\Day_5\assessment-exam-student-python\lib\exam_loader.py", line 11, 
in load
    self.write_exam(json,token)
  File "C:\Users\Admin\Bootcamp\lighthouse-data-notes\Week_1\Day_5\assessment-exam-student-python\lib\exam_loader.py", line 39, 
in write_exam
    f.write(code_content)
  File "C:\Users\Admin\anaconda3\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character 
```

cc @Matus-Knoyd @jurajkapasny 

source of fix: https://stackoverflow.com/questions/27092833/unicodeencodeerror-charmap-codec-cant-encode-characters